### PR TITLE
0.2.0

### DIFF
--- a/custom_components/kidschores/__init__.py
+++ b/custom_components/kidschores/__init__.py
@@ -62,6 +62,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Initialize the storage manager to handle persistent data.
     storage_manager = KidsChoresStorageManager(hass, STORAGE_KEY)
+    # If a stale kidschore_data file exists, wipe it out.
+    await storage_manager.async_clear_data()
+    # Initialize new file.
     await storage_manager.async_initialize()
 
     # Create the data coordinator for managing updates and synchronization.
@@ -130,6 +133,5 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
             "storage_manager"
         ]
         await storage_manager.async_clear_data()
-        await storage_manager.async_delete()  # Clear all stored data properly
 
     LOGGER.info("KidsChores entry data cleared: %s", entry.entry_id)

--- a/custom_components/kidschores/const.py
+++ b/custom_components/kidschores/const.py
@@ -198,6 +198,7 @@ ACTION_REMIND_30 = "REMIND_30"
 ATTR_ACHIEVEMENT_NAME = "achievement_name"
 ATTR_ALL_EARNED_BADGES = "all_earned_badges"
 ATTR_ALLOW_MULTIPLE_CLAIMS_PER_DAY = "allow_multiple_claims_per_day"
+ATTR_APPLICABLE_DAYS = "applicable_days"
 ATTR_AWARDED = "awarded"
 ATTR_ASSIGNED_KIDS = "assigned_kids"
 ATTR_BADGES = "badges"
@@ -269,6 +270,10 @@ SERVICE_REDEEM_REWARD = "redeem_reward"  # Redeem reward service
 SERVICE_RESET_ALL_CHORES = "reset_all_chores"  # Reset all chores service
 SERVICE_RESET_ALL_DATA = "reset_all_data"  # Reset all data service
 SERVICE_RESET_OVERDUE_CHORES = "reset_overdue_chores"  # Reset overdue chores
+SERVICE_SET_CHORE_DUE_DATE = "set_chore_due_date"  # Set or reset chores due date
+SERVICE_SKIP_CHORE_DUE_DATE = (
+    "skip_chore_due_date"  # Skip chores due date and reschedule
+)
 
 # Field Names (for consistency across services)
 FIELD_CHORE_ID = "chore_id"

--- a/custom_components/kidschores/kc_helpers.py
+++ b/custom_components/kidschores/kc_helpers.py
@@ -91,6 +91,13 @@ async def is_user_authorized_for_kid(
     if user.is_admin:
         return True
 
+    # Allow non-admin users if they are registered as a parent in KidsChores.
+    coordinator = _get_kidschores_coordinator(hass)
+    if coordinator:
+        for parent in coordinator.parents_data.values():
+            if parent.get("ha_user_id") == user.id:
+                return True
+
     coordinator: KidsChoresDataCoordinator = _get_kidschores_coordinator(hass)
     if not coordinator:
         LOGGER.warning("Authorization: No KidsChores coordinator found")

--- a/custom_components/kidschores/manifest.json
+++ b/custom_components/kidschores/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ad-ha/kidschores-ha/issues",
   "requirements": [],
-  "version": "0.1.8"
+  "version": "0.2.0"
 }

--- a/custom_components/kidschores/sensor.py
+++ b/custom_components/kidschores/sensor.py
@@ -47,6 +47,7 @@ from .const import (
     ATTR_ACHIEVEMENT_NAME,
     ATTR_ALL_EARNED_BADGES,
     ATTR_ALLOW_MULTIPLE_CLAIMS_PER_DAY,
+    ATTR_APPLICABLE_DAYS,
     ATTR_ASSIGNED_KIDS,
     ATTR_AWARDED,
     ATTR_BADGES,
@@ -404,6 +405,7 @@ class ChoreStatusSensor(CoordinatorEntity, SensorEntity):
             ATTR_SHARED_CHORE: shared,
             ATTR_GLOBAL_STATE: global_state,
             ATTR_RECURRING_FREQUENCY: chore_info.get("recurring_frequency", "None"),
+            ATTR_APPLICABLE_DAYS: chore_info.get("applicable_days", []),
             ATTR_DUE_DATE: chore_info.get("due_date", DUE_DATE_NOT_SET),
             ATTR_DEFAULT_POINTS: chore_info.get("default_points", 0),
             ATTR_PARTIAL_ALLOWED: chore_info.get("partial_allowed", False),
@@ -479,7 +481,7 @@ class KidMaxPointsEverSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{entry.entry_id}_{kid_id}_max_points_ever"
         self._entry = entry
         self._attr_translation_placeholders = {"kid_name": kid_name}
-        self.entity_id = f"sensor.kc_{kid_name}_max_points_ever"
+        self.entity_id = f"sensor.kc_{kid_name}_points_max_ever"
 
     @property
     def native_value(self):
@@ -798,7 +800,7 @@ class PendingChoreApprovalsSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_pending_chore_approvals"
         self._attr_icon = "mdi:clipboard-check-outline"
-        self.entity_id = f"sensor.kc_pending_chore_approvals"
+        self.entity_id = f"sensor.kc_global_chore_pending_approvals"
 
     @property
     def native_value(self):
@@ -976,7 +978,7 @@ class SharedChoreGlobalStateSensor(CoordinatorEntity, SensorEntity):
         self._attr_translation_placeholders = {
             "chore_name": chore_name,
         }
-        self.entity_id = f"sensor.kc_chore_global_status_{chore_name}"
+        self.entity_id = f"sensor.kc_global_chore_status_{chore_name}"
 
     @property
     def native_value(self) -> str:
@@ -998,6 +1000,7 @@ class SharedChoreGlobalStateSensor(CoordinatorEntity, SensorEntity):
             ATTR_CHORE_NAME: self._chore_name,
             ATTR_DESCRIPTION: chore_info.get("description", ""),
             ATTR_RECURRING_FREQUENCY: chore_info.get("recurring_frequency", "None"),
+            ATTR_APPLICABLE_DAYS: chore_info.get("applicable_days", []),
             ATTR_DUE_DATE: chore_info.get("due_date", "Not set"),
             ATTR_DEFAULT_POINTS: chore_info.get("default_points", 0),
             ATTR_PARTIAL_ALLOWED: chore_info.get("partial_allowed", False),
@@ -1322,7 +1325,7 @@ class AchievementSensor(CoordinatorEntity, SensorEntity):
         self._attr_translation_placeholders = {
             "achievement_name": achievement_name,
         }
-        self.entity_id = f"sensor.kc_{achievement_name}_status"
+        self.entity_id = f"sensor.kc_achievement_status_{achievement_name}"
 
     @property
     def native_value(self):
@@ -1378,7 +1381,7 @@ class ChallengeSensor(CoordinatorEntity, SensorEntity):
         self._attr_translation_placeholders = {
             "challenge_name": challenge_name,
         }
-        self.entity_id = f"sensor.kc_{challenge_name}_status"
+        self.entity_id = f"sensor.kc_challenge_status_{challenge_name}"
 
     @property
     def native_value(self):

--- a/custom_components/kidschores/services.yaml
+++ b/custom_components/kidschores/services.yaml
@@ -228,3 +228,51 @@ reset_overdue_chores:
       required: false
       selector:
         text:
+
+set_chore_due_date:
+  name: "Set Chore Due Date"
+  description: >
+    Set (or clear) the due date for a chore. Provide the chore name and, if desired,
+    a new due date. If no due date is provided the existing due date will be cleared.
+    The service will reject due dates set in the past.
+  fields:
+    chore_name:
+      name: "Chore Name"
+      description: "The name of the chore to update."
+      example: "Wash Dishes"
+      required: true
+      selector:
+        text:
+    due_date:
+      name: "Due Date"
+      description: >
+        The new due date for the chore. Use the date/time selector to choose a valid
+        date and time (in your local timezone). Leave empty to clear the due date.
+      example: "2025-03-01T23:59:00Z"
+      required: false
+      selector:
+        datetime: {}
+
+skip_chore_due_date:
+  name: "Skip Chore Due Date"
+  description: >
+    Skip the current due date of a recurring chore. This service immediately
+    reschedules the chore's due date based on its recurring frequency and resets
+    its state to pending. Any pending claims or approvals will be removed.
+  fields:
+    chore_id:
+      name: "Chore ID"
+      description: >
+        The internal ID of the chore to update. Optional if you provide a chore name.
+      example: "abc123"
+      required: false
+      selector:
+        text:
+    chore_name:
+      name: "Chore Name"
+      description: >
+        The name of the chore to update. Optional if you provide a chore ID.
+      example: "Weekly Laundry"
+      required: false
+      selector:
+        text:

--- a/custom_components/kidschores/storage_manager.py
+++ b/custom_components/kidschores/storage_manager.py
@@ -17,6 +17,10 @@ from .const import (
     DATA_REWARDS,
     DATA_PENALTIES,
     DATA_PARENTS,
+    DATA_ACHIEVEMENTS,
+    DATA_CHALLENGES,
+    DATA_PENDING_CHORE_APPROVALS,
+    DATA_PENDING_REWARD_APPROVALS,
 )
 
 
@@ -57,6 +61,10 @@ class KidsChoresStorageManager:
                 DATA_REWARDS: {},  # Dictionary of rewards keyed by internal_id.
                 DATA_PENALTIES: {},  # Dictionary of penalties keyed by internal_id.
                 DATA_PARENTS: {},  # Dictionary of parents keyed by internal_id.
+                DATA_ACHIEVEMENTS: {},  # Dictionary of achievements keyed by internal_id.
+                DATA_CHALLENGES: {},  # Dictionary of challenges keyed by internal_id.
+                DATA_PENDING_CHORE_APPROVALS: {},  # Dictionary of pending chore approvals keyed by internal_id.
+                DATA_PENDING_REWARD_APPROVALS: {},  # Dictionary of pending rewar approvals keyed by internal_id.
             }
         else:
             # Load existing data into memory.
@@ -65,85 +73,56 @@ class KidsChoresStorageManager:
 
     @property
     def data(self):
-        """Retrieve the in-memory data cache.
-
-        Returns:
-            dict: The cached data structure.
-
-        """
+        """Retrieve the in-memory data cache."""
         return self._data
 
     def get_data(self):
-        """Retrieve the data structure (alternative getter).
-
-        Returns:
-            dict: The cached data structure.
-
-        """
+        """Retrieve the data structure (alternative getter)."""
         return self._data
 
     def set_data(self, new_data: dict):
-        """Replace the entire in-memory data structure.
-
-        Args:
-            new_data (dict): New data structure to store.
-
-        """
+        """Replace the entire in-memory data structure."""
         self._data = new_data
 
     def get_kids(self):
-        """Retrieve the kids data.
-
-        Returns:
-            dict: Kids data keyed by internal_id.
-
-        """
+        """Retrieve the kids data."""
         return self._data.get(DATA_KIDS, {})
 
     def get_parents(self):
-        """Retrieve the parents data.
-
-        Returns:
-            dict: Parents data keyed by internal_id.
-
-        """
+        """Retrieve the parents data."""
         return self._data.get(DATA_PARENTS, {})
 
     def get_chores(self):
-        """Retrieve the chores data.
-
-        Returns:
-            dict: Chores data keyed by internal_id.
-
-        """
+        """Retrieve the chores data."""
         return self._data.get(DATA_CHORES, {})
 
     def get_badges(self):
-        """Retrieve the badges data.
-
-        Returns:
-            dict: Badges data keyed by internal_id.
-
-        """
+        """Retrieve the badges data."""
         return self._data.get(DATA_BADGES, {})
 
     def get_rewards(self):
-        """Retrieve the rewards data.
-
-        Returns:
-            dict: Rewards data keyed by internal_id.
-
-        """
+        """Retrieve the rewards data."""
         return self._data.get(DATA_REWARDS, {})
 
     def get_penalties(self):
-        """Retrieve the penalties data.
-
-        Returns:
-            dict: Penalties data keyed by internal_id.
-
-        """
+        """Retrieve the penalties data."""
         return self._data.get(DATA_PENALTIES, {})
+
+    def get_achievements(self):
+        """Retrieve the achievements data."""
+        return self._data.get(DATA_ACHIEVEMENTS, {})
+
+    def get_challenges(self):
+        """Retrieve the challenges data."""
+        return self._data.get(DATA_CHALLENGES, {})
+
+    def get_pending_chore_approvals(self):
+        """Retrieve the pending chore approvals data."""
+        return self._data.get(DATA_PENDING_CHORE_APPROVALS, {})
+
+    def get_pending_reward_aprovals(self):
+        """Retrieve the pending reward approvals data."""
+        return self._data.get(DATA_PENDING_REWARD_APPROVALS, {})
 
     async def link_user_to_kid(self, user_id, kid_id):
         """Link a Home Assistant user ID to a specific kid by internal_id."""
@@ -166,10 +145,7 @@ class KidsChoresStorageManager:
         return self._data.get("linked_users", {})
 
     async def async_save(self):
-        """Save the current data structure to storage asynchronously.
-
-        Logs errors if the operation fails.
-        """
+        """Save the current data structure to storage asynchronously."""
         try:
             await self._store.async_save(self._data)
             LOGGER.info("Data saved successfully to storage")
@@ -177,10 +153,8 @@ class KidsChoresStorageManager:
             LOGGER.error("Failed to save data to storage: %s", e)
 
     async def async_clear_data(self):
-        """Clear all stored data and reset to default structure.
+        """Clear all stored data and reset to default structure."""
 
-        This can be used for a full reset if required.
-        """
         LOGGER.warning("Clearing all KidsChores data and resetting storage")
         self._data = {
             DATA_KIDS: {},
@@ -189,17 +163,16 @@ class KidsChoresStorageManager:
             DATA_REWARDS: {},
             DATA_PARENTS: {},
             DATA_PENALTIES: {},
+            DATA_ACHIEVEMENTS: {},
+            DATA_CHALLENGES: {},
+            DATA_PENDING_REWARD_APPROVALS: {},
+            DATA_PENDING_CHORE_APPROVALS: {},
         }
         await self.async_save()
 
     async def async_update_data(self, key, value):
-        """Update a specific section of the data structure.
+        """Update a specific section of the data structure."""
 
-        Args:
-            key (str): Section to update (e.g., DATA_KIDS).
-            value (dict): New value for the specified section.
-
-        """
         if key in self._data:
             LOGGER.debug("Updating data for key: %s", key)
             self._data[key] = value

--- a/custom_components/kidschores/translations/en.json
+++ b/custom_components/kidschores/translations/en.json
@@ -191,26 +191,41 @@
       }
     },
     "error": {
-      "invalid_kid_count": "Invalid kid count",
-      "invalid_chore_count": "Invalid chore count",
-      "invalid_badge_count": "Invalid badge count",
-      "invalid_reward_count": "Invalid reward count",
-      "invalid_penalty_count": "Invalid penalty count",
-      "invalid_kid_name": "Invalid kid name",
-      "duplicate_kid": "A kid with this name already exists",
-      "duplicate_chore": "A chore with this name already exists",
+      "duplicate_achievement": "An achievement with this name already exists",
       "duplicate_badge": "A badge with this name already exists",
-      "duplicate_reward": "A reward with this name already exists",
+      "duplicate_challenge": "A challenge with this name already exists",
+      "duplicate_chore": "A chore with this name already exists",
+      "duplicate_kid": "A kid with this name already exists",
+      "duplicate_parent": "A parent with this name already exists",
       "duplicate_penalty": "A penalty with this name already exists",
-      "invalid_chore": "Invalid chore",
+      "duplicate_reward": "A reward with this name already exists",
+      "due_date_in_past": "Due date must be in the future.",
+      "end_date_in_past": "End Date must be in the future.",
+      "end_date_not_after_start_date": "End date must be later than start date",
+      "invalid_achievement_count": "Invalid achievement count",
+      "invalid_achievement_name": "Invalid achievement name",
       "invalid_badge": "Invalid badge",
-      "invalid_reward": "Invalid reward",
+      "invalid_badge_count": "Invalid badge count",
+      "invalid_badge_name": "Invalid badge name",
+      "invalid_challenge_count": "Invalid challenge count",
+      "invalid_challenge_name": "Invalid challenge name",
+      "invalid_chore": "Invalid chore",
+      "invalid_chore_count": "Invalid chore count",
+      "invalid_chore_name": "Invalid chore name",
+      "invalid_due_date": "Invalid due date",
+      "invalid_end_date": "Invalid end date.",
+      "invalid_kid_count": "Invalid kid count",
+      "invalid_kid_name": "Invalid kid name",
+      "invalid_parent_count": "Invalid parent count",
+      "invalid_parent_name": "Invalid parent name",
       "invalid_penalty": "Invalid penalty",
-      "no_kids": "No kids are available.",
-      "no_chores": "No chores are available.",
-      "no_badges": "No badges are available.",
-      "no_rewards": "No rewards are available.",
-      "no_penalties": "No penalties are available."
+      "invalid_penalty_count": "Invalid penalty count",
+      "invalid_penalty_name": "Invalid penalty name",
+      "invalid_reward": "Invalid reward",
+      "invalid_reward_count": "Invalid reward count",
+      "invalid_reward_name": "Invalid reward name",
+      "invalid_start_date": "Invalid start date.",
+      "start_date_in_past": "Start Date must be in the future."
     },
     "abort": {
       "single_instance_allowed": "Only a single KidsChores instance can be configured."
@@ -519,23 +534,44 @@
       }
     },
     "error": {
-      "invalid_entity": "The selected entity is invalid.",
-      "no_kids": "No kids are available.",
-      "no_chores": "No chores are available.",
-      "no_badges": "No badges are available.",
-      "no_rewards": "No rewards are available.",
-      "no_penalties": "No penalties are available."
+      "duplicate_achievement": "An achievement with this name already exists",
+      "duplicate_badge": "A badge with this name already exists",
+      "duplicate_challenge": "A challenge with this name already exists",
+      "duplicate_chore": "A chore with this name already exists",
+      "duplicate_kid": "A kid with this name already exists",
+      "duplicate_parent": "A parent with this name already exists",
+      "duplicate_penalty": "A penalty with this name already exists",
+      "duplicate_reward": "A reward with this name already exists",
+      "due_date_in_past": "Due date must be in the future.",
+      "end_date_in_past": "End Date must be in the future.",
+      "end_date_not_after_start_date": "End date must be later than start date",
+      "invalid_badge": "Invalid badge",
+      "invalid_badge_count": "Invalid badge count",
+      "invalid_chore": "Invalid chore",
+      "invalid_chore_count": "Invalid chore count",
+      "invalid_due_date": "Invalid due date",
+      "invalid_end_date": "Invalid end date.",
+      "invalid_kid_count": "Invalid kid count",
+      "invalid_kid_name": "Invalid kid name",
+      "invalid_penalty": "Invalid penalty",
+      "invalid_penalty_count": "Invalid penalty count",
+      "invalid_reward": "Invalid reward",
+      "invalid_reward_count": "Invalid reward count",
+      "invalid_start_date": "Invalid start date.",
+      "start_date_in_past": "Start Date must be in the future."
     },
     "abort": {
-      "setup_complete": "Setup Complete",
       "invalid_action": "Invalid Action",
+      "invalid_achievement": "Invalid Achievement",
+      "invalid_badge": "Invalid Badge",
+      "invalid_challenge": "Invalid Challenge",
+      "invalid_chore": "Invalid Chore",
       "invalid_entity": "Invalid Entity",
       "invalid_kid": "Invalid Kid",
       "invalid_parent": "Invalid Parent",
-      "invalid_chore": "Invalid Chore",
-      "invalid_badge": "Invalid Badge",
+      "invalid_penalty": "Invalid Penalty",
       "invalid_reward": "Invalid Reward",
-      "invalid_penalty": "Invalid Penalty"
+      "setup_complete": "Setup Complete"
     }
   },
   "selector": {
@@ -763,6 +799,38 @@
           "example": "Alice"
         }
       }
+    },
+    "set_chore_due_date": {
+      "name": "Set/Reset Chore Due Date",
+      "description": "Set (or clear) the due date for a chore. Provide the chore name and, if desired, a new due date. If no due date is provided the existing due date will be cleared. The service will reject due dates set in the past.",
+      "fields": {
+        "chore_name": {
+          "name": "Chore Name",
+          "description": "The name of the chore to update",
+          "example": "Wash Dishes"
+        },
+        "due_date": {
+          "name": "Due Date",
+          "description": "The new due date for the chore. Use the date/time selector to choose a valid date and time (in your local timezone). Leave empty to clear the due date.",
+          "example": "2025-03-01T23:59:00Z"
+        }
+      }
+    },
+    "skip_chore_due_date": {
+      "name": "Skip Chore Due Date",
+      "description": "Skip the current due date of a recurring chore. This service immediately reschedules the chore's due date based on its recurring frequency and resets its state to pending. Any pending claims or approvals will be removed.",
+      "fields": {
+        "chore_id": {
+          "name": "Chore ID",
+          "description": "The internal ID of the chore to reset (optional if chore_name is provided).",
+          "example": "abc123"
+        },
+        "chore_name": {
+          "name": "Chore Name",
+          "description": "The name of the chore to reset (optional if chore_id is provided).",
+          "example": "Wash Dishes"
+        }
+      }
     }
   },
   "entity": {
@@ -796,6 +864,18 @@
               "daily": "Daily",
               "weekly": "Weekly",
               "monthly": "Monthly"
+            }
+          },
+          "applicable_days": {
+            "name": "Applicable Days",
+            "state": {
+              "mon": "Monday",
+              "tue": "Tuesday",
+              "wed": "Wednesday",
+              "thu": "Thursday",
+              "fri": "Friday",
+              "sat": "Saturday",
+              "sun": "Sunday"
             }
           },
           "due_date": { "name": "Due Date" },
@@ -871,7 +951,7 @@
             }
           },
           "points_multiplier": { "name": "Points Multiplier" },
-          "descriptionn": { "name": "Description" },
+          "description": { "name": "Description" },
           "kids_earned": { "name": "Kids Earned" }
         }
       },
@@ -909,6 +989,18 @@
               "daily": "Daily",
               "weekly": "Weekly",
               "monthly": "Monthly"
+            }
+          },
+          "applicable_days": {
+            "name": "Applicable Days",
+            "state": {
+              "mon": "Monday",
+              "tue": "Tuesday",
+              "wed": "Wednesday",
+              "thu": "Thursday",
+              "fri": "Friday",
+              "sat": "Saturday",
+              "sun": "Sunday"
             }
           },
           "due_date": { "name": "Due Date" },
@@ -959,7 +1051,7 @@
         "state_attributes": {
           "kid_name": { "name": "Kid Name" },
           "penalty_name": { "name": "Penalty Name" },
-          "descriptionn": { "name": "Description" },
+          "description": { "name": "Description" },
           "penalty_points": { "name": "Penalty Points" }
         }
       },

--- a/custom_components/kidschores/translations/es.json
+++ b/custom_components/kidschores/translations/es.json
@@ -191,26 +191,41 @@
       }
     },
     "error": {
-      "invalid_kid_count": "Número de niños inválido",
-      "invalid_chore_count": "Número de tareas inválido",
-      "invalid_badge_count": "Cantidad de insignias inválida",
-      "invalid_reward_count": "Cantidad de recompensas inválida",
-      "invalid_penalty_count": "Cantidad de penalizaciones inválida",
-      "invalid_kid_name": "Nombre de niño inválido",
-      "duplicate_kid": "Ya existe un niño con ese nombre",
-      "duplicate_chore": "Ya existe una tarea con ese nombre",
-      "duplicate_badge": "Ya existe una insignia con ese nombre",
-      "duplicate_reward": "Ya existe una recompensa con ese nombre",
-      "duplicate_penalty": "Ya existe una penalización con ese nombre",
-      "invalid_chore": "Tarea inválida",
-      "invalid_badge": "Insignia inválida",
-      "invalid_reward": "Recompensa inválida",
-      "invalid_penalty": "Penalización inválida",
-      "no_kids": "No hay niños disponibles.",
-      "no_chores": "No hay tareas disponibles.",
-      "no_badges": "No hay insignias disponibles.",
-      "no_rewards": "No hay recompensas disponibles.",
-      "no_penalties": "No hay penalizaciones disponibles."
+      "duplicate_achievement": "Ya existe un logro con este nombre",
+      "duplicate_badge": "Ya existe una insignia con este nombre",
+      "duplicate_challenge": "Ya existe un desafío con este nombre",
+      "duplicate_chore": "Ya existe una tarea con este nombre",
+      "duplicate_kid": "Ya existe un niño con este nombre",
+      "duplicate_parent": "Ya existe un padre/madre con este nombre",
+      "duplicate_penalty": "Ya existe una penalización con este nombre",
+      "duplicate_reward": "Ya existe una recompensa con este nombre",
+      "due_date_in_past": "La fecha de vencimiento debe estar en el futuro.",
+      "end_date_in_past": "La fecha de fin debe estar en el futuro.",
+      "end_date_not_after_start_date": "La fecha de fin debe ser posterior a la fecha de inicio.",
+      "invalid_achievement_count": "Cantidad de logros no válida",
+      "invalid_achievement_name": "Nombre de logro no válido",
+      "invalid_badge": "Insignia no válida",
+      "invalid_badge_count": "Cantidad de insignias no válida",
+      "invalid_badge_name": "Nombre de insignia no válido",
+      "invalid_challenge_count": "Cantidad de desafíos no válida",
+      "invalid_challenge_name": "Nombre de desafío no válido",
+      "invalid_chore": "Tarea no válida",
+      "invalid_chore_count": "Cantidad de tareas no válida",
+      "invalid_chore_name": "Nombre de tarea no válido",
+      "invalid_due_date": "Fecha de vencimiento no válida",
+      "invalid_end_date": "Fecha de fin no válida.",
+      "invalid_kid_count": "Cantidad de niños no válida",
+      "invalid_kid_name": "Nombre de niño no válido",
+      "invalid_parent_count": "Cantidad de padres no válida",
+      "invalid_parent_name": "Nombre de padre/madre no válido",
+      "invalid_penalty": "Penalización no válida",
+      "invalid_penalty_count": "Cantidad de penalizaciones no válida",
+      "invalid_penalty_name": "Nombre de penalización no válido",
+      "invalid_reward": "Recompensa no válida",
+      "invalid_reward_count": "Cantidad de recompensas no válida",
+      "invalid_reward_name": "Nombre de recompensa no válido",
+      "invalid_start_date": "Fecha de inicio no válida.",
+      "start_date_in_past": "La fecha de inicio debe estar en el futuro."
     },
     "abort": {
       "single_instance_allowed": "Solo se puede configurar una única instancia de KidsChores."
@@ -519,23 +534,44 @@
       }
     },
     "error": {
-      "invalid_entity": "La entidad seleccionada es inválida.",
-      "no_kids": "No hay niños disponibles.",
-      "no_chores": "No hay tareas disponibles.",
-      "no_badges": "No hay insignias disponibles.",
-      "no_rewards": "No hay recompensas disponibles.",
-      "no_penalties": "No hay penalizaciones disponibles."
+      "duplicate_achievement": "Ya existe un logro con este nombre",
+      "duplicate_badge": "Ya existe una insignia con este nombre",
+      "duplicate_challenge": "Ya existe un desafío con este nombre",
+      "duplicate_chore": "Ya existe una tarea con este nombre",
+      "duplicate_kid": "Ya existe un niño con este nombre",
+      "duplicate_parent": "Ya existe un padre/madre con este nombre",
+      "duplicate_penalty": "Ya existe una penalización con este nombre",
+      "duplicate_reward": "Ya existe una recompensa con este nombre",
+      "due_date_in_past": "La fecha de vencimiento debe estar en el futuro.",
+      "end_date_in_past": "La fecha de fin debe estar en el futuro.",
+      "end_date_not_after_start_date": "La fecha de fin debe ser posterior a la fecha de inicio.",
+      "invalid_badge": "Insignia no válida",
+      "invalid_badge_count": "Cantidad de insignias no válida",
+      "invalid_chore": "Tarea no válida",
+      "invalid_chore_count": "Cantidad de tareas no válida",
+      "invalid_due_date": "Fecha de vencimiento no válida",
+      "invalid_end_date": "Fecha de fin no válida.",
+      "invalid_kid_count": "Cantidad de niños no válida",
+      "invalid_kid_name": "Nombre de niño no válido",
+      "invalid_penalty": "Penalización no válida",
+      "invalid_penalty_count": "Cantidad de penalizaciones no válida",
+      "invalid_reward": "Recompensa no válida",
+      "invalid_reward_count": "Cantidad de recompensas no válida",
+      "invalid_start_date": "Fecha de inicio no válida.",
+      "start_date_in_past": "La fecha de inicio debe estar en el futuro."
     },
     "abort": {
-      "setup_complete": "Configuración completada",
-      "invalid_action": "Acción inválida",
-      "invalid_entity": "Entidad inválida",
-      "invalid_kid": "Niño/a inválido",
-      "invalid_parent": "Padre/Madre inválido",
-      "invalid_chore": "Tarea inválida",
-      "invalid_badge": "Insignia inválida",
-      "invalid_reward": "Recompensa inválida",
-      "invalid_penalty": "Penalización inválida"
+      "invalid_action": "Acción no válida",
+      "invalid_achievement": "Logro no válido",
+      "invalid_badge": "Insignia no válida",
+      "invalid_challenge": "Desafío no válido",
+      "invalid_chore": "Tarea no válida",
+      "invalid_entity": "Entidad no válida",
+      "invalid_kid": "Niño no válido",
+      "invalid_parent": "Padre/Madre no válido",
+      "invalid_penalty": "Penalización no válida",
+      "invalid_reward": "Recompensa no válida",
+      "setup_complete": "Configuración Completa"
     }
   },
   "selector": {
@@ -763,6 +799,38 @@
           "example": "Alice"
         }
       }
+    },
+    "set_chore_due_date": {
+      "name": "Establecer/Restablecer Fecha de Vencimiento de la Tarea",
+      "description": "Establece (o borra) la fecha de vencimiento de una tarea. Proporciona el nombre de la tarea y, si lo deseas, una nueva fecha de vencimiento. Si no se proporciona una fecha, se borrará la existente. El servicio rechazará las fechas en el pasado.",
+      "fields": {
+        "chore_name": {
+          "name": "Nombre de la Tarea",
+          "description": "El nombre de la tarea a actualizar",
+          "example": "Lavar Platos"
+        },
+        "due_date": {
+          "name": "Fecha de Vencimiento",
+          "description": "La nueva fecha de vencimiento de la tarea. Usa el selector de fecha/hora para elegir una fecha y hora válidas (en tu zona horaria local). Déjalo vacío para borrar la fecha de vencimiento.",
+          "example": "2025-03-01T23:59:00Z"
+        }
+      }
+    },
+    "skip_chore_due_date": {
+      "name": "Saltar Fecha de Vencimiento de la Tarea",
+      "description": "Salta la fecha de vencimiento actual de una tarea recurrente. Este servicio reprograma inmediatamente la fecha de vencimiento de la tarea según su frecuencia de repetición y restablece su estado a pendiente. Se eliminarán todas las reclamaciones o aprobaciones pendientes.",
+      "fields": {
+        "chore_id": {
+          "name": "ID de la Tarea",
+          "description": "El ID interno de la tarea a restablecer (opcional si se proporciona chore_name).",
+          "example": "abc123"
+        },
+        "chore_name": {
+          "name": "Nombre de la Tarea",
+          "description": "El nombre de la tarea a restablecer (opcional si se proporciona chore_id).",
+          "example": "Lavar Platos"
+        }
+      }
     }
   },
   "entity": {
@@ -796,6 +864,18 @@
               "daily": "Diaria",
               "weekly": "Semanal",
               "monthly": "Mensual"
+            }
+          },
+          "applicable_days": {
+            "name": "Applicable Days",
+            "state": {
+              "mon": "Lunes",
+              "tue": "Martes",
+              "wed": "Miércoles",
+              "thu": "Jueves",
+              "fri": "Viernes",
+              "sat": "Sábado",
+              "sun": "Domingo"
             }
           },
           "due_date": { "name": "Fecha de Vencimiento" },
@@ -911,6 +991,18 @@
               "daily": "Diaria",
               "weekly": "Semanal",
               "monthly": "Mensual"
+            }
+          },
+          "applicable_days": {
+            "name": "Applicable Days",
+            "state": {
+              "mon": "Lunes",
+              "tue": "Martes",
+              "wed": "Miércoles",
+              "thu": "Jueves",
+              "fri": "Viernes",
+              "sat": "Sábado",
+              "sun": "Domingo"
             }
           },
           "due_date": { "name": "Fecha de Vencimiento" },


### PR DESCRIPTION
## New Features
* Add new **Set/Reset Chore Due Date** Action/Service (closes #48)

* Add new **Skip Chore Due Date** Action/Service (closes #55)

* Add Applicable Days as extra attribute to Chore Sensor and Global Chore Sensor (closes #54)

## What's Changed
* Set Disapprove Chores/Rewards buttons to be always available. Check for pending claims is done on press (closes #35)

* Ensure Due Dates on Chores are always in the future (closes #46)

* Ensure Start Date and End Date on Challenges are always in the future (closes #46)

* Rename Achievement sensor entity_id (closes #49)

* Rename Challenge sensor entity_id (closes #49)

* Fix issue with non-admin parents not being able to claim chores/rewards on behalf of kids (closes #50)

* Revise Manual Points name check (closes #51)

* Fix issue with Reset Overdue Chore action/service not working properly for specific chore/kid. (closes #52)
  This now includes several options:
  * Reset a specific overdue chore (for all kids)
  * Reset all overdue chores for a specific kid only
  * Reset a specific overdue chore for a specific kid
  * Reset all overdue chores
 
* Minor changes:
  * Ensure that `kidschores_data` storage file is fully wiped on setup if data exists from previous entry.
  * Add new translation keys for services and other fields
  * Revise translations keys missing on errors during Configuration and Options
  * Ensure config_entries data is always updated for due date changes.
    _sometimes HA skips updates that only affect config_entry.options_
  * Add missing dictionaries to data file on entry setup