### PR TITLE
0.2.2

### DIFF
--- a/custom_components/kidschores/__init__.py
+++ b/custom_components/kidschores/__init__.py
@@ -32,32 +32,8 @@ from .storage_manager import KidsChoresStorageManager
 from .services import async_setup_services, async_unload_services
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the integration via configuration.yaml (if supported in the future).
-
-    Args:
-        hass: Home Assistant core object.
-        config: Configuration dictionary.
-
-    Returns:
-        bool: True if successful, False otherwise.
-
-    """
-    LOGGER.info("Setting up KidsChores integration via YAML is currently unsupported")
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up the integration from a config entry.
-
-    Args:
-        hass: Home Assistant core object.
-        entry: Configuration entry created via the UI.
-
-    Returns:
-        bool: True if successful, raises an exception otherwise.
-
-    """
+    """Set up the integration from a config entry."""
     LOGGER.info("Starting setup for KidsChores entry: %s", entry.entry_id)
 
     # Initialize the storage manager to handle persistent data.

--- a/custom_components/kidschores/config_flow.py
+++ b/custom_components/kidschores/config_flow.py
@@ -419,7 +419,7 @@ class KidsChoresConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except ValueError:
                 errors["base"] = "invalid_badge_count"
 
-        schema = vol.Schema({vol.Required("badge_count", default=1): vol.Coerce(int)})
+        schema = vol.Schema({vol.Required("badge_count", default=0): vol.Coerce(int)})
         return self.async_show_form(
             step_id="badge_count", data_schema=schema, errors=errors
         )
@@ -481,7 +481,7 @@ class KidsChoresConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except ValueError:
                 errors["base"] = "invalid_reward_count"
 
-        schema = vol.Schema({vol.Required("reward_count", default=1): vol.Coerce(int)})
+        schema = vol.Schema({vol.Required("reward_count", default=0): vol.Coerce(int)})
         return self.async_show_form(
             step_id="reward_count", data_schema=schema, errors=errors
         )
@@ -541,7 +541,7 @@ class KidsChoresConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except ValueError:
                 errors["base"] = "invalid_penalty_count"
 
-        schema = vol.Schema({vol.Required("penalty_count", default=1): vol.Coerce(int)})
+        schema = vol.Schema({vol.Required("penalty_count", default=0): vol.Coerce(int)})
         return self.async_show_form(
             step_id="penalty_count", data_schema=schema, errors=errors
         )
@@ -602,7 +602,7 @@ class KidsChoresConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except ValueError:
                 errors["base"] = "invalid_achievement_count"
         schema = vol.Schema(
-            {vol.Required("achievement_count", default=1): vol.Coerce(int)}
+            {vol.Required("achievement_count", default=0): vol.Coerce(int)}
         )
         return self.async_show_form(
             step_id="achievement_count", data_schema=schema, errors=errors
@@ -676,7 +676,7 @@ class KidsChoresConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except ValueError:
                 errors["base"] = "invalid_challenge_count"
         schema = vol.Schema(
-            {vol.Required("challenge_count", default=1): vol.Coerce(int)}
+            {vol.Required("challenge_count", default=0): vol.Coerce(int)}
         )
         return self.async_show_form(
             step_id="challenge_count", data_schema=schema, errors=errors
@@ -809,7 +809,7 @@ class KidsChoresConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 parents_summary.append(parent["name"])
 
         summary = (
-            f"Kids: {', '.join(kid_data['name'] for kid_data in self._kids_temp.values()) or 'None'}\n\n"
+            f"\nKids: {', '.join(kid_data['name'] for kid_data in self._kids_temp.values()) or 'None'}\n\n"
             f"Parents: {', '.join(parents_summary) or 'None'}\n\n"
             f"Chores: {', '.join(chore_data['name'] for chore_data in self._chores_temp.values()) or 'None'}\n\n"
             f"Badges: {', '.join(badge_data['name'] for badge_data in self._badges_temp.values()) or 'None'}\n\n"

--- a/custom_components/kidschores/flow_helpers.py
+++ b/custom_components/kidschores/flow_helpers.py
@@ -515,12 +515,12 @@ def build_challenge_schema(kids_dict, chores_dict, default=None):
                     step=0.1,
                 )
             ),
-            vol.Optional("start_date", default=default.get("start_date")): vol.Any(
-                None, selector.DateTimeSelector()
-            ),
-            vol.Optional("end_date", default=default.get("end_date")): vol.Any(
-                None, selector.DateTimeSelector()
-            ),
+            vol.Required(
+                "start_date", default=default.get("start_date")
+            ): selector.DateTimeSelector(),
+            vol.Required(
+                "end_date", default=default.get("end_date")
+            ): selector.DateTimeSelector(),
             vol.Required("internal_id", default=internal_id_default): str,
         }
     )

--- a/custom_components/kidschores/manifest.json
+++ b/custom_components/kidschores/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ad-ha/kidschores-ha/issues",
   "requirements": [],
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/custom_components/kidschores/sensor.py
+++ b/custom_components/kidschores/sensor.py
@@ -860,7 +860,7 @@ class PendingRewardApprovalsSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_pending_reward_approvals"
         self._attr_icon = "mdi:gift-open-outline"
-        self.entity_id = f"sensor.kc_pending_reward_approvals"
+        self.entity_id = f"sensor.kc_global_pending_reward_approvals"
 
     @property
     def native_value(self):


### PR DESCRIPTION
## What's Changed
* Make Start and End dates on Challenges mandatory and not able to be left blank (closes #83)
* Fix issue with Kids not being removed from Parents list if Kid is deleted (closes #76)
* Fix Workflow for Chores with Multiple Chores per Day setup, that would be kept as Approved and not return to Claimed (closes #77)
* Fix issue with `str` errors on Chore Approval (closes #79 and #83)
* Fix issue with some lists being created as dictionaries on data creation during ConfigFlow if data not set by user
* Update methods to remove entities for chores no longer assigned to a Kid (closes #80)
* Fix issue with claimed chores and rewards were left hanging if chores/rewards were deleted.
* Rename entity_id for `Pending Reward Approval` (closes #84)
* Change default value on ConfigFlow steps for Badges, Rewards, Penalties, Achievements and Challenges from 1 to 0.
 