### PR TITLE
Fix call to _check_overdue_chores in _update_chore function

### DIFF
--- a/custom_components/kidschores/coordinator.py
+++ b/custom_components/kidschores/coordinator.py
@@ -977,7 +977,7 @@ class KidsChoresDataCoordinator(DataUpdateCoordinator):
 
         LOGGER.debug("Updated chore '%s' with ID: %s", chore_info["name"], chore_id)
 
-        self._check_overdue_chores()
+        self.hass.async_create_task(self._check_overdue_chores())
 
     # -- Badges
     def _create_badge(self, badge_id: str, badge_data: dict[str, Any]):


### PR DESCRIPTION
Wasn't able to get the current updated nightly build working after the most recent changes., maybe this was recently added, but I hadn't seen it previously.  This fix seemed to take care of it.

 2025-03-05 19:46:39.640 WARNING (MainThread) [py.warnings] /workspaces/core/config/custom_components/kidschores/coordinator.py:980: RuntimeWarning: coroutine 'KidsChoresDataCoordinator._check_overdue_chores' was never awaited