### PR TITLE
Due Date handling timezone issues / rescheduling #132

### DIFF
--- a/custom_components/kidschores/coordinator.py
+++ b/custom_components/kidschores/coordinator.py
@@ -3381,7 +3381,7 @@ class KidsChoresDataCoordinator(DataUpdateCoordinator):
 
     # Persist new due dates on config entries
     # This is not being used currently, but was refactored so it calls a new function _update_chore_due_date_in_config
-    # which can be used to update a single chore's due date and requency.  New fuction can be used in multiple places.
+    # which can be used to update a single chore's due date and frequency.  New function can be used in multiple places.
 
     async def _update_all_chore_due_dates_in_config(self) -> None:
         """Update due dates for all chores in config_entry.options."""


### PR DESCRIPTION
As stated in issue #132, some of the changes stated below were accidentally already pulled in as part of the #127 pull.   This pull completes all of the work to date.

# Improvements Made

## Timezone Handling & Date Defaults
- Fixed issues where timezones were not respected during rescheduling.  In US time zones, this would often result in evening chores being incorrectly scheduled to the next day, they was most noticeable when using applicable day or non-daily recurrence.
- Ensured that new chore creation without a specified due date properly defaults to local time (e.g., setting a default due time of 23:59).

## Code Refactoring & Consolidation
- Consolidated duplicate code sections in chore state processing.
- Centralized common functionality to reduce redundancy across methods.

## Centralized Rescheduling Method
- Rebuilt the rescheduling method to serve as the single source for all rescheduling logic.
- Modified various methods and services to use this centralized rescheduling function.
- Improved handling so that if a chore was due yesterday, it now schedules it for later today (if within the allowed time) rather than forcing a one-day shift; if past the due time, it finds the next valid day.

## Centralized Configuration Update
- Built a new method to update the config entry options for due dates and recurring frequency settings.
- Replaced multiple scattered config update calls with calls to this centralized update function.

## Enhanced Set Date Functionality
- Moved the logic out of the services and into the coordinator for future re-use as well as the ability to easily use other required centralized functions.
- Updated the set date function to call the coordinator's new config update method.
- Enhanced that method to remove any recurring frequency other than daily, weekly, or none when the due date is cleared.

## Removed Redundant Applicable Day Checks
- Eliminated applicable day checks in the overdue chore logic, as the centralized rescheduling now always computes and stores the correct next due date.

## Logging Enhancements
- Add more detailed logging around rescheduling decisions to aid in debugging edge cases.

