### PR TITLE
CFOF Changes for all badge types

### DIFF
--- a/custom_components/kidschores/const.py
+++ b/custom_components/kidschores/const.py
@@ -401,7 +401,6 @@ CONF_BADGE_PERIODIC_RECURRENT = "recurrent"
 CONF_BADGE_POINTS_MULTIPLIER = "points_multiplier"
 CONF_BADGE_REQUIRED_CHORES = "required_chores"
 CONF_BADGE_RESET_GRACE_PERIOD = "reset_grace_period"
-CONF_BADGE_RESET_PERIOD = "reset_period"
 CONF_BADGE_RESET_PERIODICALLY = "reset_periodically"
 CONF_BADGE_RESET_SCHEDULE = "reset_schedule"
 CONF_BADGE_RESET_TYPE = "reset_type"
@@ -607,7 +606,6 @@ DATA_BADGE_POINTS_MULTIPLIER = "points_multiplier"
 DATA_BADGE_REQUIRED_CHORES = "required_chores"
 DATA_BADGE_RESET_CRITERIA = "reset_criteria"
 DATA_BADGE_RESET_GRACE_PERIOD = "reset_grace_period"
-DATA_BADGE_RESET_PERIOD = "reset_period"
 DATA_BADGE_RESET_PERIODICALLY = "reset_periodically"
 DATA_BADGE_RESET_SCHEDULE = "reset_schedule"
 DATA_BADGE_RESET_TYPE = "reset_type"
@@ -1167,8 +1165,21 @@ TRANS_KEY_CFOF_DUPLICATE_PENALTY = "duplicate_penalty"
 TRANS_KEY_CFOF_DUPLICATE_REWARD = "duplicate_reward"
 TRANS_KEY_CFOF_END_DATE_IN_PAST = "end_date_in_past"
 TRANS_KEY_CFOF_END_DATE_NOT_AFTER_START_DATE = "end_date_not_after_start_date"
+TRANS_KEY_CFOF_ERROR_ASSIGNED_KIDS = "At least one kid must be assigned."
 TRANS_KEY_CFOF_ERROR_AWARD_POINTS_MINIMUM = (
     "Award points must be greater than 0 when award mode is {}."
+)
+TRANS_KEY_CFOF_ERROR_BADGE_CUSTOM_RESET_DATE_REQUIRED = (
+    "Custom reset date is required when reset type is custom."
+)
+TRANS_KEY_CFOF_ERROR_BADGE_END_DATE_REQUIRED = (
+    "End date is required when reset schedule is custom."
+)
+TRANS_KEY_CFOF_ERROR_BADGE_RESET_TYPE_REQUIRED = (
+    "Reset type is required when periodic reset is enabled."
+)
+TRANS_KEY_CFOF_ERROR_BADGE_START_DATE_REQUIRED = (
+    "Start date is required when reset schedule is custom."
 )
 TRANS_KEY_CFOF_ERROR_REWARD_SELECTION = (
     "An award reward must be selected when award mode is {}."

--- a/custom_components/kidschores/flow_helpers.py
+++ b/custom_components/kidschores/flow_helpers.py
@@ -444,9 +444,9 @@ def build_badge_cumulative_schema(default: dict = None, rewards_list: list = Non
 def build_badge_daily_schema(default: dict = None, rewards_list: list = None):
     """Build schema for daily badges that reset every day."""
     default = default or {}
-    rewards_list = [
-        {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + rewards_list
+    rewards_list = [{"value": const.CONF_EMPTY, "label": const.LABEL_NONE}] + (
+        rewards_list or []
+    )
     internal_id_default = default.get(const.CONF_INTERNAL_ID, str(uuid.uuid4()))
 
     return vol.Schema(
@@ -537,8 +537,10 @@ def build_badge_periodic_schema(
 
     rewards_list = [
         {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + rewards_list
-    chores_list = [{"value": const.CONF_EMPTY, "label": const.LABEL_NONE}] + chores_list
+    ] + rewards_list or []
+    chores_list = [
+        {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
+    ] + chores_list or []
     internal_id_default = default.get(const.CONF_INTERNAL_ID, str(uuid.uuid4()))
 
     return vol.Schema(
@@ -571,11 +573,11 @@ def build_badge_periodic_schema(
             vol.Optional(
                 const.CONF_BADGE_START_DATE,
                 default=default.get(const.CONF_BADGE_START_DATE, None),
-            ): selector.DateSelector(),
+            ): vol.Any(None, selector.DateSelector()),
             vol.Optional(
                 const.CONF_BADGE_END_DATE,
                 default=default.get(const.CONF_BADGE_END_DATE, None),
-            ): selector.DateSelector(),
+            ): vol.Any(None, selector.DateSelector()),
             vol.Optional(
                 const.CONF_BADGE_PERIODIC_RECURRENT,
                 default=default.get(const.CONF_BADGE_PERIODIC_RECURRENT, False),
@@ -660,10 +662,10 @@ def build_badge_achievement_schema(
     internal_id_default = default.get(const.CONF_INTERNAL_ID, str(uuid.uuid4()))
     achievements_list = [
         {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + achievements_list
+    ] + achievements_list or []
     rewards_list = [
         {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + rewards_list
+    ] + rewards_list or []
 
     return vol.Schema(
         {
@@ -740,10 +742,10 @@ def build_badge_challenge_schema(
     internal_id_default = default.get(const.CONF_INTERNAL_ID, str(uuid.uuid4()))
     challenges_list = [
         {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + challenges_list
+    ] + challenges_list or []
     rewards_list = [
         {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + rewards_list
+    ] + rewards_list or []
 
     return vol.Schema(
         {
@@ -820,7 +822,7 @@ def build_badge_special_occasions_schema(
     internal_id_default = default.get(const.CONF_INTERNAL_ID, str(uuid.uuid4()))
     rewards_list = [
         {"value": const.CONF_EMPTY, "label": const.LABEL_NONE}
-    ] + rewards_list
+    ] + rewards_list or []
 
     kids_options = [
         {"value": kid_id, "label": kid_name} for kid_name, kid_id in kids_dict.items()


### PR DESCRIPTION
Options flow field validations and cleanup for all badge types
Refactored error handling in options flow to align with your original approach (now that I better understand how it works)
Schema changes where required to accept empty fields for dates
Config flow changes for cumulative badge setup
Added various constants related to errors.  Removed a constant that a mistakenly used in periodic badge
Adjustments to _migrate_badges method because it was constantly running on all badges.  This still needs further review and thought

Open items - There are two comments I left that are marked as #### **** CLS  that I'm hoping you can take a closer look at when you have time.