### PR TITLE
Add service to remove awarded badges from kids

### DIFF
--- a/custom_components/kidschores/const.py
+++ b/custom_components/kidschores/const.py
@@ -1036,6 +1036,7 @@ SERVICE_CLAIM_CHORE = "claim_chore"
 SERVICE_DISAPPROVE_CHORE = "disapprove_chore"
 SERVICE_DISAPPROVE_REWARD = "disapprove_reward"
 SERVICE_REDEEM_REWARD = "redeem_reward"
+SERVICE_REMOVE_AWARDED_BADGES = "remove_awarded_badges"
 SERVICE_RESET_ALL_CHORES = "reset_all_chores"
 SERVICE_RESET_ALL_DATA = "reset_all_data"
 SERVICE_RESET_BONUSES = "reset_bonuses"
@@ -1049,6 +1050,7 @@ SERVICE_SKIP_CHORE_DUE_DATE = "skip_chore_due_date"
 # ------------------------------------------------------------------------------------------------
 # Field Names (for service calls)
 # ------------------------------------------------------------------------------------------------
+FIELD_BADGE_NAME = "badge_name"
 FIELD_BONUS_NAME = "bonus_name"
 FIELD_CHORE_ID = "chore_id"
 FIELD_CHORE_NAME = "chore_name"

--- a/custom_components/kidschores/kc_helpers.py
+++ b/custom_components/kidschores/kc_helpers.py
@@ -208,6 +208,16 @@ def get_penalty_id_by_name(
     return None
 
 
+def get_badge_id_by_name(
+    coordinator: KidsChoresDataCoordinator, badge_name: str
+) -> Optional[str]:
+    """Retrieve the badge_id for a given badge_name."""
+    for badge_id, badges_info in coordinator.badges_data.items():
+        if badges_info.get(const.DATA_BADGE_NAME) == badge_name:
+            return badge_id
+    return None
+
+
 def get_bonus_id_by_name(
     coordinator: KidsChoresDataCoordinator, bonus_name: str
 ) -> Optional[str]:

--- a/custom_components/kidschores/services.yaml
+++ b/custom_components/kidschores/services.yaml
@@ -368,3 +368,25 @@ reset_rewards:
       required: false
       selector:
         text:
+
+remove_awarded_badges:
+  name: "Remove Awarded Badges"
+  description: >
+    Remove all awarded badges for all kids. Optionally, provide badge_name to reset a
+    specific badge across all kids. Use kid_name to reset all badges for a specific kid.
+    Combine both to reset a specific badge for a specific kid.
+  fields:
+    kid_name:
+      name: "Kid Name"
+      description: "The kid awarded badges will be removed from."
+      example: "Bob"
+      required: false
+      selector:
+        text:
+    badge_name:
+      name: "Badge Name"
+      description: "The name of the badge to remove."
+      example: "Chore Master"
+      required: false
+      selector:
+        text:

--- a/custom_components/kidschores/translations/de.json
+++ b/custom_components/kidschores/translations/de.json
@@ -1204,6 +1204,22 @@
           "example": "Eiscreme"
         }
       }
+    },
+    "remove_awarded_badges": {
+      "name": "Entferne vergebene Abzeichen",
+      "description": "Entferne alle vergebenen Abzeichen für alle Kinder. Optional: Gib einen Abzeichennamen an, um ein bestimmtes Abzeichen bei allen Kindern zurückzusetzen. Verwende den Kindnamen, um alle Abzeichen für ein bestimmtes Kind zurückzusetzen. Kombiniere beides, um ein bestimmtes Abzeichen für ein bestimmtes Kind zurückzusetzen.",
+      "fields": {
+        "kid_name": {
+          "name": "Kindname",
+          "description": "Von welchem Kind die vergebenen Abzeichen entfernt werden.",
+          "example": "Bob"
+        },
+        "badge_name": {
+          "name": "Abzeichenname",
+          "description": "Der Name des Abzeichens, das entfernt werden soll.",
+          "example": "Chore Master"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/kidschores/translations/en.json
+++ b/custom_components/kidschores/translations/en.json
@@ -1204,6 +1204,22 @@
           "example": "Ice Cream"
         }
       }
+    },
+    "remove_awarded_badges": {
+      "name": "Remove Awarded Badges",
+      "description": "Remove all awarded badges for all kids. Optionally, provide badge name to reset a specific badge across all kids. Use kid name to reset all badges for a specific kid. Combine both to reset a specific badge for a specific kid.",
+      "fields": {
+        "kid_name": {
+          "name": "Kid Name",
+          "description": "The kid awarded badges will be removed from.",
+          "example": "Bob"
+        },
+        "badge_name": {
+          "name": "Badge Name",
+          "description": "The name of the badge to remove.",
+          "example": "Chore Master"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/kidschores/translations/es.json
+++ b/custom_components/kidschores/translations/es.json
@@ -1204,6 +1204,22 @@
           "example": "Helado"
         }
       }
+    },
+    "remove_awarded_badges": {
+      "name": "Eliminar Insignias Otorgadas",
+      "description": "Elimina todas las insignias otorgadas a todos los niños. Opcionalmente, proporciona el nombre de la insignia para reiniciar una insignia específica en todos los niños. Usa el nombre del niño para reiniciar todas las insignias de un niño específico. Combínalos para reiniciar una insignia específica para un niño específico.",
+      "fields": {
+        "kid_name": {
+          "name": "Nombre del Niño",
+          "description": "El niño del que se eliminarán las insignias otorgadas.",
+          "example": "Bob"
+        },
+        "badge_name": {
+          "name": "Nombre de la Insignia",
+          "description": "El nombre de la insignia que se eliminará.",
+          "example": "Chore Master"
+        }
+      }
     }
   },
   "entity": {


### PR DESCRIPTION
Created service to remove awarded badges from kids.  
- Similar approach as other services where it can be by kid_name or by badge_name or both.
- Handles all badge types as well as extra fields that are included in kid_data.  (There is some logic in clearing those fields, specifically for cumulative, that needs confirmed to ensure it makes sense, but it's easy to adjust)
- Handles badge removal for badges that have been deleted.  Essentially just removing the badge_name from the kid_data
- Centralized method created to support all badge removal operations from within the integration or from the service.

Other Changes:
In method _migrate_badges, set the badge_type to cumulative if no badge type is found
Added debug logging for _check_badges because of an issue I was troubleshooting.  Will leave for now, but can probably be reduced later.
Added and updated some logging for overdue chores.

