### PR TITLE
fix: resolve migration bugs causing duplicate buttons and stale appro…

### DIFF
--- a/custom_components/kidschores/coordinator.py
+++ b/custom_components/kidschores/coordinator.py
@@ -3118,8 +3118,10 @@ class KidsChoresDataCoordinator(DataUpdateCoordinator):
         if not chore_info:
             return None
 
+        # Default to INDEPENDENT if completion_criteria not set (backward compatibility)
+        # This ensures pre-migration chores without completion_criteria are treated as INDEPENDENT
         completion_criteria = chore_info.get(
-            const.DATA_CHORE_COMPLETION_CRITERIA, const.SENTINEL_EMPTY
+            const.DATA_CHORE_COMPLETION_CRITERIA, const.COMPLETION_CRITERIA_INDEPENDENT
         )
 
         if completion_criteria == const.COMPLETION_CRITERIA_INDEPENDENT:

--- a/custom_components/kidschores/migration_pre_v42.py
+++ b/custom_components/kidschores/migration_pre_v42.py
@@ -100,6 +100,13 @@ class PreV42Migrator:
         # Fixes Python float arithmetic drift (e.g., 27.499999999999996 → 27.5)
         self._round_float_precision()
 
+        # Phase 7: Clean up orphaned/deprecated dynamic entities
+        # This is called unconditionally because _initialize_data_from_config() only
+        # calls this for KC 3.x config migrations, leaving storage-only users with
+        # orphaned entities from previous versions (e.g., integer-delta buttons).
+        self.coordinator.remove_deprecated_button_entities()
+        self.coordinator.remove_deprecated_sensor_entities()
+
         const.LOGGER.info("All pre-v42 migrations completed successfully")
 
     def _migrate_independent_chores(self) -> None:


### PR DESCRIPTION
…vals

Bug 1 - Duplicate Points Buttons:
- remove_deprecated_button_entities() was only called during KC 3.x config sync, leaving storage-only migrations with orphaned integer-delta buttons (e.g., _adjust_points_10) alongside new float-delta buttons (_adjust_points_10.0)
- Fix: Add unconditional entity cleanup as Phase 7 of run_all_migrations()

Bug 2 - Stale Chore Approvals:
- _get_approval_period_start() defaulted missing completion_criteria to SENTINEL_EMPTY (""), causing INDEPENDENT chores to take SHARED code path which returned None for approval_period_start, making is_approved_in_current_period() incorrectly return True for old approvals
- Fix: Default to COMPLETION_CRITERIA_INDEPENDENT for backward compatibility